### PR TITLE
Add timestamp support to API

### DIFF
--- a/Discord Webhook/EmbedBuilder.cs
+++ b/Discord Webhook/EmbedBuilder.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace Discord.Webhook;
@@ -10,6 +11,7 @@ public class EmbedBuilder
 	private string? _title;
 	private string? _description;
 	private string? _url;
+	private DateTime? _timestamp;
 	private Image? _image;
 	private Thumbnail? _thumbnail;
 	private readonly List<Field> _fields = new();
@@ -142,6 +144,17 @@ public class EmbedBuilder
 	}
 
 	/// <summary>
+	///     Sets the timestamp of the embed, this appears at the bottom of the embed
+	/// </summary>
+	/// <param name="url">The timestamp to display on the embed</param>
+	/// <returns>The updated embed builder</returns>
+	public EmbedBuilder WithTimestamp(DateTime timestamp)
+	{
+		_timestamp = timestamp;
+		return this;
+	}
+
+	/// <summary>
 	///     Sets a video on the embed using a <see cref="Video" />
 	/// </summary>
 	/// <param name="video">The <see cref="Video" /> which represents the media to show on the embed</param>
@@ -201,6 +214,7 @@ public class EmbedBuilder
 			thumbnail = _thumbnail,
 			footer = _footer,
 			url = _url,
+			timestamp = _timestamp?.ToString("O"),
 			video = _video,
 			author = _author,
 			provider = _provider

--- a/Discord Webhook/WebhookObject.cs
+++ b/Discord Webhook/WebhookObject.cs
@@ -146,6 +146,11 @@ public class Embed
 	[DataMember] public string? url;
 
 	/// <summary>
+	///     the timestamp of the embed
+	/// </summary>
+	[DataMember] public string? timestamp;
+
+	/// <summary>
 	///     the color of the embed
 	/// </summary>
 	public DColor Color = Colors.Black;

--- a/TestingApp/Program.cs
+++ b/TestingApp/Program.cs
@@ -24,6 +24,7 @@ public static class Program
 			builder.WithTitle("Discord-Webhook lib")
 				.WithDescription("Building embed with 'AddEmbed(Action<EmbedBuilder> embedBuilderFunction)'")
 				.WithUrl("https://github.com/ToshiroZ/Discord-Webhook")
+				.WithTimestamp(DateTime.UtcNow)
 				.WithThumbnail("https://www.thegatewaypundit.com/wp-content/uploads/trump-mugshot-1.jpg")
 				.WithColor(Colors.Magenta)
 				.WithImage("https://i.imgur.com/ZGPxFN2.jpg")


### PR DESCRIPTION
This makes it possible to add a timestamp to the json payload.

```diff,csharp
var obj = new WebhookObject();
obj.AddEmbed(builder =>
{
	builder.WithTitle("Discord-Webhook lib")
		.WithDescription("Building embed with 'AddEmbed(Action<EmbedBuilder> embedBuilderFunction)'")
+		.WithTimestamp(DateTime.UtcNow)
		.WithThumbnail("https://www.thegatewaypundit.com/wp-content/uploads/trump-mugshot-1.jpg")
		.WithColor(Colors.Magenta)
		.WithImage("https://i.imgur.com/ZGPxFN2.jpg")
		.AddField("New Field", "This is a new field")
		.WithFooter("DiscordUser",
			"https://www.thegatewaypundit.com/wp-content/uploads/trump-mugshot-1.jpg");
});
```

Displays in discord as:

![image](https://github.com/ToshiroZ/Discord-Webhook/assets/48300131/9f2a27e9-170c-4a7a-aa59-384768e14cab)
